### PR TITLE
Fix for StyleSheets from CDN (crossorigin Attribute)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ dist/
 
 # Grunt usually preprocesses files such as coffeescript, compass... inside the .tmp directory
 .tmp/
+
+# Visual Studio Code
+.vscode

--- a/src/loaderStylesheet.js
+++ b/src/loaderStylesheet.js
@@ -134,7 +134,7 @@ me.loader.css.element = function(url, success, failed) {
 	var element = global.document.createElement('link');
 
 	// The browser supports it, enable crossorigin.
-	element.crossorigin = true;
+	element.crossOrigin = 'anonymous';
 
 	// Set the actual URL that we're going to request to load for our library.
 	element.href = url;


### PR DESCRIPTION
Previously, despite a CDN specifying the `Access-Control-Allow-Origin: *` header, fallback would fail to confirm a stylesheet was loaded due to CORS exception from browser. This PR attempts to fix this issue.

Based on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes), this property has been renamed to `crossOrigin` (camel case), and based on the [spec](https://html.spec.whatwg.org/multipage/infrastructure.html#cors-settings-attribute) its value changed to `anonymous`.

This fixes the `export` check locally (and avoids redundant loading of local assets) on Win 8.1 against:
- FF `45.0b6`
- FF Developer Edition `46.0a2 (2016-02-19)`
- Chrome `48.0.2564.109 m` & `48.0.2564.116 m`
- IE `11.0.9600.18205`
