### PR TITLE
Fix #54: Grunt lint fails

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -128,7 +128,7 @@
 		"space-in-brackets": [2, "never"],
 		"space-infix-ops": 2,
 		"space-return-throw-case": 2,
-		"space-unary-word-ops": 2,
+		"space-unary-ops": 2,
 		"strict": 0,
 		"use-isnan": 2,
 		"valid-jsdoc": 2,


### PR DESCRIPTION
Replace space-unary-word-ops by space-unary-ops to reflect the same
change in eslint.

See http://eslint.org/docs/rules/space-unary-word-ops

After this change, `grunt lint` results in

`Done, without errors.`
