### PR TITLE
Fix for "toLowerCase is not a function"

### DIFF
--- a/fallback.js
+++ b/fallback.js
@@ -50,7 +50,7 @@
 
 	// Setup individual utility function.
 	fallback.utility = function(type) {
-		fallback['is_' + type.toLowerCase()] = function(variable) {
+		fallback['is_' + type.toString().toLowerCase()] = function(variable) {
 			/*eslint-disable*/
 			return typeof variable !== 'undefined' && Object.prototype.toString.call(variable) == '[object ' + type + ']';
 			/*eslint-enable*/


### PR DESCRIPTION
Just adding toString() before the toLowerCase() call fixes the "toLowerCase is not a function" error that occurs on some websites.